### PR TITLE
Implemented changes to fix issue(http error 400) related to get cmd output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # winrm-s  Change Log
 
 ## Unreleased
-None
+* [Issue #25](https://github.com/opscode/winrm-s/pull/25): [Fix for knife-windows issue 218](https://github.com/opscode/knife-windows/issues/218)
 
 Last release: 0.2.4
 -------------------


### PR DESCRIPTION
knife windows winrm bootstrap with sspi fails - HTTP Error 400.

Refer - https://github.com/chef/knife-windows/issues/218 

This is due to WinRb/WinRM#134  changes, So added changes to fix get_command_output related issue.
