### PR TITLE
fix issues around encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ rvm:
   - 2.0.0
   - 2.1.0
 
-script: bundle exec rake spec
+script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 rvm:
-#  - 1.8.7
-#  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.0
 
 script: bundle exec rake
+before_install:
+   - gem update bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 Unreleased
 --------------
 
+Release: 0.3.2
+--------------
+* Strip UTF-8 BOM from response added by win2k8R2 since newer WinRM versions now use UTF-8
+* Decode all authorized payloads, not just successful ones so an unsuccesful command error can be communicated
+
 Release: 0.3.1
 --------------
 * [Issue #27](https://github.com/chef/winrm-s/pull/27): Fixes problem with AllowUnencrypted being true and using negotiate

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem "rspec"
+  gem 'pry'
+  gem 'rspec'
   gem 'rake'
   gem 'nokogiri', '~> 1.6.2'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,16 @@
-require 'bundler/gem_tasks'
+require 'bundler'
+require 'rspec/core/rake_task'
+
+Bundler::GemHelper.install_tasks
+
+task :default => [:unit_spec, :functional_spec]
+
+desc "Run all functional specs in spec directory"
+RSpec::Core::RakeTask.new(:functional_spec) do |t|
+t.pattern = 'spec/functional/**/*_spec.rb'
+end
+
+desc "Run all unit specs in spec directory"
+RSpec::Core::RakeTask.new(:unit_spec) do |t|
+t.pattern = 'spec/unit/**/*_spec.rb'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rspec/core/rake_task'
 
 Bundler::GemHelper.install_tasks
 
-task :default => [:unit_spec, :functional_spec]
+task :default => [:unit_spec]
 
 desc "Run all functional specs in spec directory"
 RSpec::Core::RakeTask.new(:functional_spec) do |t|

--- a/lib/winrm-s/version.rb
+++ b/lib/winrm-s/version.rb
@@ -17,6 +17,6 @@
 #
 
 module WinrmS
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
   MAJOR, MINOR, TINY = VERSION.split('.')
 end

--- a/lib/winrm/http/auth.rb
+++ b/lib/winrm/http/auth.rb
@@ -83,7 +83,7 @@ class HTTPClient
           end
           # ignore unknown authentication scheme
         end
-      elsif res.status == HTTP::Status::OK
+      else
         decrypted_content = res.content
         @authenticator.each do |auth|
           next unless auth.set? # hasn't be set, don't use it

--- a/lib/winrm/winrm_service_patch.rb
+++ b/lib/winrm/winrm_service_patch.rb
@@ -66,7 +66,7 @@ module WinRM
         output = Output.new
         REXML::XPath.match(resp_doc, "//#{NS_WIN_SHELL}:Stream").each do |n|
           next if n.text.nil? || n.text.empty?
-          stream = { n.attributes['Name'].to_sym => Base64.decode64(n.text) }
+          stream = { n.attributes['Name'].to_sym => Base64.decode64(n.text).force_encoding('utf-8').sub("\xEF\xBB\xBF", "") }
           output[:data] << stream
           yield stream[:stdout], stream[:stderr] if block_given?
         end

--- a/spec/functional/sspi_nego_encrypt_decrypt_spec.rb
+++ b/spec/functional/sspi_nego_encrypt_decrypt_spec.rb
@@ -10,7 +10,7 @@ def assert_prerequisites
 end
 
 
-describe "Test sspinegotiate with encrypt/decrypt via WinRM", :windows_and_func_spec_enabled do
+describe "Test sspinegotiate with encrypt/decrypt via WinRM" do
   before(:all) do
     assert_prerequisites
     # Remember the user setting.
@@ -21,7 +21,7 @@ describe "Test sspinegotiate with encrypt/decrypt via WinRM", :windows_and_func_
 
   before do
     %x{winrm set winrm/config/service @{AllowUnencrypted="false"}}
-    @winrm = WinRM::WinRMWebService.new(ENV["test_winrm_endpoint"], :sspinegotiate, :user => ENV["test_winrm_user"], :pass => ENV["test_winrm_pass"])
+    @winrm = WinRM::WinRMWebService.new(ENV["test_winrm_endpoint"], :sspinegotiate, :user => ENV["test_winrm_user"].dup, :pass => ENV["test_winrm_pass"].dup)
   end
 
   after(:all) do
@@ -46,20 +46,5 @@ describe "Test sspinegotiate with encrypt/decrypt via WinRM", :windows_and_func_
       outvar << stdout
     end
     expect(outvar).to match(/Windows IP Configuration/)
-  end
-
-  describe "Negative test:" do
-    before do
-      %x{winrm set winrm/config/service @{AllowUnencrypted="true"}}
-    end
-    after do
-      %x{winrm set winrm/config/service @{AllowUnencrypted="false"}}
-    end
-
-    describe "when AllowUnencrypted is set to true" do
-      it "should raise an exception" do
-        expect{@winrm.run_cmd('ipconfig')}.to raise_exception
-      end
-    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,12 +10,7 @@ def unix?
   !windows?
 end
 
-def windows_and_func_spec_enabled?
-  windows? and ENV["enable_winrms_func_spec"]
-end
-
 RSpec.configure do |config|
   config.filter_run_excluding :windows_only => true unless windows?
-  config.filter_run_excluding :windows_and_func_spec_enabled => true unless windows_and_func_spec_enabled?
   config.filter_run_excluding :unix_only => true unless unix?
 end

--- a/winrm-s.gemspec
+++ b/winrm-s.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Gem that extends the functionality of the WinRM gem to support the Microsoft Negotiate protocol when authenticating to a remote WinRM endpoint from a Windows system}
   s.description = s.summary
 
-  s.add_dependency "winrm", "~> 1.3.0"
+  s.add_dependency "winrm", "~> 1.3", ">= 1.3.6"
 
   %w(rspec-core rspec-expectations rspec-mocks rspec_junit_formatter).each { |gem| s.add_development_dependency gem }
 


### PR DESCRIPTION
There are currently 2 issues with winrm-s in regards to encoding:

1. A couple months ago, the WinRM gem changed the default codepage to UTF-8. This created a regression on win2k8R2 (not win2012R2) in Test-Kitchen runs. When TK transfered files to the instance, a UTF-8 BOM was being inserted in responses breaking the CSV parser. This was soon fixed in WinRM and this PR makes the same fix here.
2. sspi decoding only happens for `200` responses. If there is a `500` error, like a wsman timeout, then the payload is not decrypted and a `invalid byte sequence in UTF-8` is raised because the encrypted payload has non UTF-8 characters. See [this discussion](https://discourse.chef.io/t/how-to-bootstrap-private-ip-node-to-open-source-server/7502) for a scenario where this occurs. This PR, always decrypts the payload unless a 401 occurs.