### PR TITLE
Fixes incompatibility with winrm 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # winrm-s  Change Log
+Release: 0.3.5
+--------------
+* Fixes incompatibility with winrm 1.6 where a consuming gem sets the transport option to `:negotiate` and results in an error since this gem has no awareness of that setting
+
 Release: 0.3.4
 --------------
 * [Issue #32](https://github.com/chef/winrm-s/issues/32): Fixes incompatibility with winrm 1.5

--- a/lib/winrm-s/version.rb
+++ b/lib/winrm-s/version.rb
@@ -17,6 +17,6 @@
 #
 
 module WinrmS
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
   MAJOR, MINOR, TINY = VERSION.split('.')
 end

--- a/lib/winrm/winrm_service_patch.rb
+++ b/lib/winrm/winrm_service_patch.rb
@@ -29,7 +29,8 @@ module WinRM
         @xfer = HTTP::HttpSSPINegotiate.new(endpoint, opts[:user], opts[:pass], opts)
       when :ssl
         @xfer = HTTP::HttpSSL.new(endpoint, opts[:user], opts[:pass], opts[:ca_trust_path], opts)
-      end
+      when :negotiate
+        @xfer = HTTP::HttpNegotiate.new(endpoint, opts[:user], opts[:pass], opts)
     end
 
     # Get the builder obj for output request


### PR DESCRIPTION
One may run into errors if the winrm 1.6 gem is loaded and consuming applications (like inspec) are using the `:negotiate` transport option. The monkey patch in this gem has no awareness of that setting and therefore fails to set the transport at all.

The best fix is to release the latest Test-Kitchen which no longer uses this deprecated gem. However, the best short term fix is to simply add the `:negotiate` option here and have users that run in to these errors, update this gem.
